### PR TITLE
v0.2.0: Expose norm types to end user & normalize over last two dimensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pytorch-tsmixer"
-version = "0.1.1"
+version = "0.2.0"
 authors = [
   { name="Konstantin Ditschuneit" }
 ]

--- a/test/test_tsmixer.py
+++ b/test/test_tsmixer.py
@@ -17,7 +17,9 @@ class TSMixerTest(unittest.TestCase):
         prediction_length=st.integers(min_value=5, max_value=50),
         input_channels=st.integers(min_value=1, max_value=10),
         num_blocks=st.integers(min_value=1, max_value=5),
-        batch_size=st.integers(min_value=1, max_value=10),
+        batch_size=st.integers(min_value=2, max_value=10),
+        normalize_before=st.booleans(),
+        norm_type=st.sampled_from(("batch", "layer")),
     )
     def test_tsmixer_shapes(
         self,
@@ -26,6 +28,8 @@ class TSMixerTest(unittest.TestCase):
         input_channels: int,
         num_blocks: int,
         batch_size: int,
+        normalize_before: bool,
+        norm_type: str,
     ) -> None:
         """Test the output shape of TSMixer model.
 
@@ -43,6 +47,8 @@ class TSMixerTest(unittest.TestCase):
             prediction_length=prediction_length,
             input_channels=input_channels,
             num_blocks=num_blocks,
+            normalize_before=normalize_before,
+            norm_type=norm_type,
         )
 
         x = torch.randn(batch_size, sequence_length, input_channels)

--- a/test/test_tsmixer_ext.py
+++ b/test/test_tsmixer_ext.py
@@ -9,7 +9,7 @@ from torchtsmixer import TSMixerExt  # Replace with the actual import
 
 class TestTSMixerExt(unittest.TestCase):
     @given(
-        batch_size=st.integers(min_value=1, max_value=10),
+        batch_size=st.integers(min_value=2, max_value=10),
         sequence_length=st.integers(min_value=1, max_value=20),
         prediction_length=st.integers(min_value=1, max_value=20),
         input_channels=st.integers(min_value=1, max_value=5),
@@ -17,6 +17,8 @@ class TestTSMixerExt(unittest.TestCase):
         static_channels=st.integers(min_value=1, max_value=5),
         hidden_channels=st.integers(min_value=1, max_value=64),
         output_channels=st.integers(min_value=1, max_value=5),
+        normalize_before=st.booleans(),
+        norm_type=st.sampled_from(("batch", "layer")),
     )
     def test_output_shape(
         self,
@@ -28,6 +30,8 @@ class TestTSMixerExt(unittest.TestCase):
         static_channels: int,
         hidden_channels: int,
         output_channels: int,
+        normalize_before: bool,
+        norm_type: str,
     ) -> None:
         """Test the output shape of TSMixerExt model.
 
@@ -49,6 +53,8 @@ class TestTSMixerExt(unittest.TestCase):
             hidden_channels=hidden_channels,
             static_channels=static_channels,
             output_channels=output_channels,
+            normalize_before=normalize_before,
+            norm_type=norm_type,
         )
 
         x_hist = torch.randn(batch_size, sequence_length, input_channels)

--- a/torchtsmixer/__init__.py
+++ b/torchtsmixer/__init__.py
@@ -1,2 +1,4 @@
 from .tsmixer import TSMixer
 from .tsmixer_ext import TSMixerExt
+
+__all__ = ["TSMixer", "TSMixerExt"]

--- a/torchtsmixer/layers.py
+++ b/torchtsmixer/layers.py
@@ -7,29 +7,56 @@ import torch.nn.functional as F
 from torch import Tensor, nn
 
 
-class TimeBatchNorm1d(nn.BatchNorm1d):
-    """A batch normalization applied to the time dimension of a sequence."""
+class TimeBatchNorm2d(nn.BatchNorm1d):
+    """A batch normalization layer that normalizes over the last two dimensions of a
+    sequence in PyTorch, mimicking Keras behavior.
 
-    def forward(self, x: Tensor) -> Tensor:
-        """
+    This class extends nn.BatchNorm1d to apply batch normalization across time and
+    feature dimensions.
+
+    Attributes:
+        num_time_steps (int): Number of time steps in the input.
+        num_channels (int): Number of channels in the input.
+    """
+
+    def __init__(self, normalized_shape: tuple[int, int]):
+        """Initializes the TimeBatchNorm2d module.
 
         Args:
-            x: A 3D tensor with shape (N, S, L) where S is the sequence dimension,
-               and L is the feature dimension length.
+            normalized_shape (tuple[int, int]): A tuple (num_time_steps, num_channels)
+                representing the shape of the time and feature dimensions to normalize.
+        """
+        num_time_steps, num_channels = normalized_shape
+        super().__init__(num_channels * num_time_steps)
+        self.num_time_steps = num_time_steps
+        self.num_channels = num_channels
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Applies the batch normalization over the last two dimensions of the input tensor.
+
+        Args:
+            x (Tensor): A 3D tensor with shape (N, S, C), where N is the batch size,
+                S is the number of time steps, and C is the number of channels.
 
         Returns:
-            A 3D tensor, where the batch normalization has been applied to the
-            channel dimension.
+            Tensor: A 3D tensor with batch normalization applied over the last two dims.
 
         Raises:
-            AssertionError: If the input tensor is not 3D.
+            ValueError: If the input tensor is not 3D.
         """
         if x.ndim != 3:
-            raise ValueError(f"Expected 3D x tensor, but got {x.ndim}D tensor instead.")
+            raise ValueError(f"Expected 3D input tensor, but got {x.ndim}D tensor instead.")
 
-        x = x.permute(0, 2, 1)
+        # Reshaping input to combine time and feature dimensions for normalization
+        x = x.reshape(x.shape[0], -1, 1)
+
+        # Applying batch normalization
         x = super().forward(x)
-        return x.permute(0, 2, 1)
+
+        # Reshaping back to original dimensions (N, S, C)
+        x = x.reshape(x.shape[0], self.num_time_steps, self.num_channels)
+
+        return x
 
 
 class FeatureMixing(nn.Module):
@@ -39,6 +66,7 @@ class FeatureMixing(nn.Module):
     uses dropout for regularization, and allows for different activation functions.
 
     Args:
+        sequence_length: The length of the sequences to be transformed.
         input_channels: The number of input channels to the module.
         output_channels: The number of output channels from the module.
         ff_dim: The dimension of the feed-forward network internal to the module.
@@ -50,20 +78,27 @@ class FeatureMixing(nn.Module):
 
     def __init__(
         self,
+        sequence_length: int,
         input_channels: int,
         output_channels: int,
         ff_dim: int,
         activation_fn: Callable[[torch.Tensor], torch.Tensor] = F.relu,
         dropout_rate: float = 0.1,
         normalize_before: bool = True,
-        norm_type: type[nn.Module] = TimeBatchNorm1d,
+        norm_type: type[nn.Module] = TimeBatchNorm2d,
     ):
         """Initializes the FeatureMixing module with the provided parameters."""
         super().__init__()
 
-        self.norm_before = norm_type(input_channels) if normalize_before else nn.Identity()
+        self.norm_before = (
+            norm_type((sequence_length, input_channels))
+            if normalize_before
+            else nn.Identity()
+        )
         self.norm_after = (
-            norm_type(output_channels) if not normalize_before else nn.Identity()
+            norm_type((sequence_length, output_channels))
+            if not normalize_before
+            else nn.Identity()
         )
 
         self.activation_fn = activation_fn
@@ -119,6 +154,7 @@ class ConditionalFeatureMixing(nn.Module):
 
     def __init__(
         self,
+        sequence_length: int,
         input_channels: int,
         output_channels: int,
         static_channels: int,
@@ -132,6 +168,7 @@ class ConditionalFeatureMixing(nn.Module):
 
         self.fr_static = nn.Linear(static_channels, output_channels)
         self.fm = FeatureMixing(
+            sequence_length,
             input_channels + output_channels,
             output_channels,
             ff_dim,
@@ -186,15 +223,15 @@ class TimeMixing(nn.Module):
 
     def __init__(
         self,
-        input_channels: int,
         sequence_length: int,
+        input_channels: int,
         activation_fn: Callable = F.relu,
         dropout_rate: float = 0.1,
-        norm_type: type[nn.Module] = TimeBatchNorm1d,
+        norm_type: type[nn.Module] = TimeBatchNorm2d,
     ):
         """Initializes the TimeMixing module with the specified parameters."""
         super().__init__()
-        self.norm = norm_type(input_channels)  # Assuming a dummy channel dimension
+        self.norm = norm_type((sequence_length, input_channels))
         self.activation_fn = activation_fn
         self.dropout = nn.Dropout(dropout_rate)
         self.fc1 = nn.Linear(sequence_length, sequence_length)
@@ -227,8 +264,9 @@ class MixerLayer(nn.Module):
     dependencies and feature interactions respectively.
 
     Args:
-        input_channels: The number of input channels to the module.
         sequence_length: The length of the input sequences.
+        input_channels: The number of input channels to the module.
+        output_channels: The number of output channels from the module.
         ff_dim: The inner dimension of the feedforward network used in feature mixing.
         activation_fn: The activation function used in both time and feature mixing.
         dropout_rate: The dropout probability used in both mixing operations.
@@ -236,9 +274,9 @@ class MixerLayer(nn.Module):
 
     def __init__(
         self,
+        sequence_length: int,
         input_channels: int,
         output_channels: int,
-        sequence_length: int,
         ff_dim: int,
         activation_fn: Callable = F.relu,
         dropout_rate: float = 0.1,
@@ -249,13 +287,14 @@ class MixerLayer(nn.Module):
         super().__init__()
 
         self.time_mixing = TimeMixing(
-            input_channels,
             sequence_length,
+            input_channels,
             activation_fn,
             dropout_rate,
             norm_type=norm_type,
         )
         self.feature_mixing = FeatureMixing(
+            sequence_length,
             input_channels,
             output_channels,
             ff_dim,
@@ -288,10 +327,10 @@ class ConditionalMixerLayer(nn.Module):
     that are influenced by both dynamic and static features.
 
     Args:
+        sequence_length: The length of the input sequences.
         input_channels: The number of input channels of the dynamic features.
         output_channels: The number of output channels after feature mixing.
         static_channels: The number of channels in the static feature input.
-        sequence_length: The length of the input sequences.
         ff_dim: The inner dimension of the feedforward network used in feature mixing.
         activation_fn: The activation function used in both mixing operations.
         dropout_rate: The dropout probability used in both mixing operations.
@@ -299,10 +338,10 @@ class ConditionalMixerLayer(nn.Module):
 
     def __init__(
         self,
+        sequence_length: int,
         input_channels: int,
         output_channels: int,
         static_channels: int,
-        sequence_length: int,
         ff_dim: int,
         activation_fn: Callable = F.relu,
         dropout_rate: float = 0.1,
@@ -312,13 +351,14 @@ class ConditionalMixerLayer(nn.Module):
         super().__init__()
 
         self.time_mixing = TimeMixing(
-            input_channels,
             sequence_length,
+            input_channels,
             activation_fn,
             dropout_rate,
             norm_type=norm_type,
         )
         self.feature_mixing = ConditionalFeatureMixing(
+            sequence_length,
             input_channels,
             output_channels=output_channels,
             static_channels=static_channels,

--- a/torchtsmixer/layers.py
+++ b/torchtsmixer/layers.py
@@ -125,6 +125,8 @@ class ConditionalFeatureMixing(nn.Module):
         ff_dim: int,
         activation_fn: Callable = F.relu,
         dropout_rate: float = 0.1,
+        normalize_before: bool = False,
+        norm_type: type[nn.Module] = nn.LayerNorm,
     ):
         super().__init__()
 
@@ -135,8 +137,8 @@ class ConditionalFeatureMixing(nn.Module):
             ff_dim,
             activation_fn,
             dropout_rate,
-            normalize_before=False,
-            norm_type=nn.LayerNorm,
+            normalize_before=normalize_before,
+            norm_type=norm_type,
         )
 
     def forward(
@@ -240,15 +242,27 @@ class MixerLayer(nn.Module):
         ff_dim: int,
         activation_fn: Callable = F.relu,
         dropout_rate: float = 0.1,
+        normalize_before: bool = False,
+        norm_type: type[nn.Module] = nn.LayerNorm,
     ):
         """Initializes the MixLayer with time and feature mixing modules."""
         super().__init__()
 
         self.time_mixing = TimeMixing(
-            input_channels, sequence_length, activation_fn, dropout_rate
+            input_channels,
+            sequence_length,
+            activation_fn,
+            dropout_rate,
+            norm_type=norm_type,
         )
         self.feature_mixing = FeatureMixing(
-            input_channels, output_channels, ff_dim, activation_fn, dropout_rate
+            input_channels,
+            output_channels,
+            ff_dim,
+            activation_fn,
+            dropout_rate,
+            norm_type=norm_type,
+            normalize_before=normalize_before,
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
@@ -292,6 +306,8 @@ class ConditionalMixerLayer(nn.Module):
         ff_dim: int,
         activation_fn: Callable = F.relu,
         dropout_rate: float = 0.1,
+        normalize_before: bool = False,
+        norm_type: type[nn.Module] = nn.LayerNorm,
     ):
         super().__init__()
 
@@ -300,7 +316,7 @@ class ConditionalMixerLayer(nn.Module):
             sequence_length,
             activation_fn,
             dropout_rate,
-            norm_type=nn.LayerNorm,
+            norm_type=norm_type,
         )
         self.feature_mixing = ConditionalFeatureMixing(
             input_channels,
@@ -309,6 +325,8 @@ class ConditionalMixerLayer(nn.Module):
             ff_dim=ff_dim,
             activation_fn=activation_fn,
             dropout_rate=dropout_rate,
+            normalize_before=normalize_before,
+            norm_type=norm_type,
         )
 
     def forward(self, x: torch.Tensor, x_static: torch.Tensor) -> torch.Tensor:

--- a/torchtsmixer/tsmixer.py
+++ b/torchtsmixer/tsmixer.py
@@ -4,7 +4,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from .layers import MixerLayer, TimeBatchNorm1d, feature_to_time, time_to_feature
+from .layers import MixerLayer, TimeBatchNorm2d, feature_to_time, time_to_feature
 
 
 class TSMixer(nn.Module):
@@ -54,7 +54,7 @@ class TSMixer(nn.Module):
             "batch",
             "layer",
         }, f"Invalid norm_type: {norm_type}, must be one of batch, layer."
-        norm_type = TimeBatchNorm1d if norm_type == "batch" else nn.LayerNorm
+        norm_type = TimeBatchNorm2d if norm_type == "batch" else nn.LayerNorm
 
         # Build mixer layers
         self.mixer_layers = self._build_mixer(

--- a/torchtsmixer/tsmixer_ext.py
+++ b/torchtsmixer/tsmixer_ext.py
@@ -7,7 +7,7 @@ import torch.nn.functional as F
 from .layers import (
     ConditionalFeatureMixing,
     ConditionalMixerLayer,
-    TimeBatchNorm1d,
+    TimeBatchNorm2d,
     feature_to_time,
     time_to_feature,
 )
@@ -68,13 +68,14 @@ class TSMixerExt(nn.Module):
             "batch",
             "layer",
         }, f"Invalid norm_type: {norm_type}, must be one of batch, layer."
-        norm_type = TimeBatchNorm1d if norm_type == "batch" else nn.LayerNorm
+        norm_type = TimeBatchNorm2d if norm_type == "batch" else nn.LayerNorm
 
         self.fc_hist = nn.Linear(sequence_length, prediction_length)
         self.fc_out = nn.Linear(hidden_channels, output_channels or input_channels)
 
         self.feature_mixing_hist = ConditionalFeatureMixing(
-            input_channels + extra_channels,
+            sequence_length=prediction_length,
+            input_channels=input_channels + extra_channels,
             output_channels=hidden_channels,
             static_channels=static_channels,
             ff_dim=ff_dim,
@@ -84,7 +85,8 @@ class TSMixerExt(nn.Module):
             norm_type=norm_type,
         )
         self.feature_mixing_future = ConditionalFeatureMixing(
-            extra_channels,
+            sequence_length=prediction_length,
+            input_channels=extra_channels,
             output_channels=hidden_channels,
             static_channels=static_channels,
             ff_dim=ff_dim,


### PR DESCRIPTION
This PR attempts to integrate the improvements/fixes suggested in issue #2 .


## 1.  Choosing normalization type and application before/after mixing

`TSMixer`and `TSMixerExt` now let the user decide whether to use `batch` or `layer` normaliyation and when to apply the normalization by exposing two new (optional) parameters:

```
normalize_before: Whether to apply layer normalization before or after mixer layer.
norm_type: Type of normalization to use. "batch" or "layer".
```
The default values (`TSMixer(..., normalize_before=True, norm_type=batch)` and `TSMixerExt(..., normalize_before=False, norm_type=layer)` are chosen to follow the description in the original paper.

## 2. Batch normalization

I tried to adapt the batch normalization according to the `keras` implementation available in [google-research](https://github.com/google-research/google-research/tree/master/tsmixer/tsmixer_basic). Afaik pytorch's batch normalization layer always normalizes over axis 1 and does not support normalizing over two axes. My "solution" is to broadcast the last two axes into axis 1, normalize, and broadcast back into the original shape:
```
        # Reshaping input to combine time and feature dimensions for normalization
        x = x.reshape(x.shape[0], -1, 1)

        # Applying batch normalization
        x = super().forward(x)

        # Reshaping back to original dimensions (N, S, C)
        x = x.reshape(x.shape[0], self.num_time_steps, self.num_channels)
```
It's not a nice solution, but I can't come up with a better way.